### PR TITLE
DEV-866: UTF-8 BOM on drift CSV export

### DIFF
--- a/rtc-drift-test/index.html
+++ b/rtc-drift-test/index.html
@@ -463,7 +463,10 @@ els.csv.onclick = () => {
   ];
   const csv = meta.concat(monitor.toCsvRows()).join("\n");
   const a = document.createElement("a");
-  a.href = URL.createObjectURL(new Blob([csv], { type: "text/csv" }));
+  // UTF-8 BOM (explicit escape, not a literal, so formatters can't silently
+  // strip it): without it Excel opens the CSV as ANSI and the metadata's
+  // "·" separators render as "Â·" (seen in the first field CSV exports).
+  a.href = URL.createObjectURL(new Blob(["\ufeff", csv], { type: "text/csv;charset=utf-8" }));
   a.download = `s3r-rtc-drift_${deviceLabel.replace(/[^\w-]+/g, "_")}_${new Date().toISOString().slice(0, 19).replace(/[:T]/g, "-")}.csv`;
   a.click();
   // Delay revocation: revoking immediately after click() can cancel the


### PR DESCRIPTION
One-liner: overnight-run CSVs opened in Excel showed the metadata separators as `Â·` (UTF-8 read as ANSI, spotted in Mark's 57F4 export). The blob now starts with an explicit `\ufeff` BOM and declares `charset=utf-8`. Data columns were never affected — pure ASCII.

🤖 Generated with [Claude Code](https://claude.com/claude-code)